### PR TITLE
Add TaCZ magazine and attachment NBT support for sizes and colors

### DIFF
--- a/targets/forge-1.20.1/src/main/java/com/sighs/petiteinventory/config/BorderThemeCache.java
+++ b/targets/forge-1.20.1/src/main/java/com/sighs/petiteinventory/config/BorderThemeCache.java
@@ -7,7 +7,6 @@ import net.minecraft.world.item.ItemStack;
 import net.minecraftforge.registries.ForgeRegistries;
 
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 
 public class BorderThemeCache {
@@ -20,56 +19,71 @@ public class BorderThemeCache {
         COLOR_MAP.putAll(BorderThemeFileStore.loadColors());
     }
 
-    /* 对外统一入口：无 ItemStack 时退化为仅按 Item 匹配 */
+    /* Entry point used when no ItemStack is available. */
     public static BorderTheme getTheme(Item item) {
         return getTheme(item, ItemStack.EMPTY);
     }
 
-    /* 核心实现：带 ItemStack 可读取 NBT 做精确匹配 */
+    /* Supports exact NBT matching for TaCZ weapons, magazines and attachments. */
     public static BorderTheme getTheme(Item item, ItemStack stack) {
         if (item == null) return BorderTheme.DEFAULT;
 
-        // 1. 精确 ID 匹配（含 NBT 片段 key）
-        String itemId = ForgeRegistries.ITEMS.getKey(item).toString();
-        BorderTheme theme = COLOR_MAP.get(itemId);
+        ResourceLocation registryId = ForgeRegistries.ITEMS.getKey(item);
+        if (registryId == null) return BorderTheme.DEFAULT;
 
-// 2. TACZ 枪械按 GunId 精确匹配（直接读根层级）
-        if (theme == null && itemId.equals("tacz:modern_kinetic_gun") && stack.hasTag()) {
-            String gunId = stack.getTag().getString("GunId");
-            if (gunId != null && !gunId.isEmpty()) {
-                // ✅ 修正：NBT键格式与命令生成器保持一致
-                String preciseKey = itemId + "{GunId:\"" + gunId + "\"}";
-                theme = COLOR_MAP.get(preciseKey);
-            }
-        }
+        String itemId = registryId.toString();
+
+        // 1. Exact NBT rule has priority.
+        String preciseKey = getNBTKey(itemId, stack);
+        BorderTheme theme = preciseKey == null ? null : COLOR_MAP.get(preciseKey);
         if (theme != null) return theme;
 
-        // 3. 标签匹配
-        ResourceLocation itemIdRL = ForgeRegistries.ITEMS.getKey(item);
-        if (itemIdRL != null) {
-            for (Map.Entry<String, BorderTheme> tagEntry : COLOR_MAP.entrySet()) {
-                if (tagEntry.getKey().startsWith("TAG:")) {
-                    String tagName = tagEntry.getKey().substring(4);
-                    ResourceLocation tagId = new ResourceLocation(tagName);
-                    if (ForgeRegistries.ITEMS.tags() != null &&
-                            ForgeRegistries.ITEMS.tags().getTag(
-                                    net.minecraft.tags.ItemTags.create(tagId)
-                            ).contains(item)) {
-                        TAG_CACHE.put(itemId, tagEntry.getValue());
-                        return tagEntry.getValue();
-                    }
-                }
+        // 2. Generic item ID rule.
+        theme = COLOR_MAP.get(itemId);
+        if (theme != null) return theme;
+
+        // 3. Tag rules.
+        for (Map.Entry<String, BorderTheme> tagEntry : COLOR_MAP.entrySet()) {
+            if (!tagEntry.getKey().startsWith("TAG:")) continue;
+
+            String tagName = tagEntry.getKey().substring(4);
+            ResourceLocation tagId = new ResourceLocation(tagName);
+            if (ForgeRegistries.ITEMS.tags() != null
+                    && ForgeRegistries.ITEMS.tags().getTag(
+                    net.minecraft.tags.ItemTags.create(tagId)
+            ).contains(item)) {
+                TAG_CACHE.put(itemId, tagEntry.getValue());
+                return tagEntry.getValue();
             }
         }
 
-        // 4. 缓存的标签匹配
+        // 4. Cached tag match.
         theme = TAG_CACHE.get(itemId);
-        if (theme != null) return theme;
-
-        return BorderTheme.DEFAULT;
+        return theme != null ? theme : BorderTheme.DEFAULT;
     }
 
-    /* 供指令调用：key 支持带 NBT 片段 */
+    private static String getNBTKey(String itemId, ItemStack stack) {
+        if (stack == null || stack.isEmpty() || !stack.hasTag()) return null;
+
+        var tag = stack.getTag();
+        String nbtField;
+
+        if (itemId.equals("taczmagazines:magazine") && tag.contains("MagazineFamily")) {
+            nbtField = "MagazineFamily";
+        } else if (itemId.equals("tacz:modern_kinetic_gun") && tag.contains("GunId")) {
+            nbtField = "GunId";
+        } else if (itemId.equals("tacz:attachment") && tag.contains("AttachmentId")) {
+            nbtField = "AttachmentId";
+        } else {
+            return null;
+        }
+
+        String value = tag.getString(nbtField);
+        if (value == null || value.isEmpty()) return null;
+
+        return itemId + "{" + nbtField + ":\"" + value + "\"}";
+    }
+
     public static void setTheme(String itemId, BorderTheme theme) {
         COLOR_MAP.put(itemId, theme);
         TAG_CACHE.remove(itemId);

--- a/targets/forge-1.20.1/src/main/java/com/sighs/petiteinventory/config/ItemSizeRuleCache.java
+++ b/targets/forge-1.20.1/src/main/java/com/sighs/petiteinventory/config/ItemSizeRuleCache.java
@@ -17,6 +17,7 @@ public class ItemSizeRuleCache {
      */
     public static void putEntry(ItemSizeRule rule) {
         String result = rule.result;
+
         for (String match : rule.match) {
             if (match.startsWith("#")) {
                 TagMapCache.put(match.replace("#", ""), result);
@@ -97,16 +98,25 @@ public class ItemSizeRuleCache {
     private static String getNBTKey(String itemId, ItemStack stack) {
         if (!stack.hasTag()) return null;
 
-        // TACZ枪械支持
-        if (itemId.equals("tacz:modern_kinetic_gun") && stack.getTag().contains("GunId")) {
-            String gunId = stack.getTag().getString("GunId");
-            if (gunId != null && !gunId.isEmpty()) {
-                return itemId + "{GunId:\"" + gunId + "\"}";
-            }
+        var tag = stack.getTag();
+        String nbtField;
+
+        if (itemId.equals("taczmagazines:magazine") && tag.contains("MagazineFamily")) {
+            nbtField = "MagazineFamily";
+        } else if (itemId.equals("tacz:modern_kinetic_gun") && tag.contains("GunId")) {
+            nbtField = "GunId";
+        } else if (itemId.equals("tacz:attachment") && tag.contains("AttachmentId")) {
+            nbtField = "AttachmentId";
+        } else {
+            return null;
         }
 
-        // 可以扩展其他模组的NBT匹配规则
-        return null;
+        String value = tag.getString(nbtField);
+        if (value == null || value.isEmpty()) {
+            return null;
+        }
+
+        return itemId + "{" + nbtField + ":\"" + value + "\"}";
     }
 
     public static String matchTag(String tagId) {
@@ -143,9 +153,9 @@ public class ItemSizeRuleCache {
 
         // 合并所有缓存（NBT优先级最高，覆盖其他）
         Map<String, String> allItems = new HashMap<>();
-        allItems.putAll(TagMapCache);      // 标签配置
-        allItems.putAll(UnitMapCache);     // 普通物品
-        allItems.putAll(NBTMapCache);      // NBT物品（优先级最高）
+        allItems.putAll(TagMapCache); // 标签配置
+        allItems.putAll(UnitMapCache); // 普通物品
+        allItems.putAll(NBTMapCache); // NBT物品（优先级最高）
 
         // 按尺寸分组
         allItems.forEach((item, size) -> {

--- a/targets/forge-1.20.1/src/main/java/com/sighs/petiteinventory/inventory/BorderTheme.java
+++ b/targets/forge-1.20.1/src/main/java/com/sighs/petiteinventory/inventory/BorderTheme.java
@@ -1,15 +1,20 @@
 package com.sighs.petiteinventory.inventory;
 
 public enum BorderTheme {
-    DEFAULT("default", "默认", 1.0f, 1.0f, 1.0f),      // 原版物品栏灰色
-    BLUE("blue", "高贵蓝", 0.3f, 0.5f, 1.0f),          // 蓝色
-    PURPLE("purple", "高贵紫", 0.7f, 0.3f, 1.0f),      // 紫色
-    ORANGE("orange", "高贵橙", 1.0f, 0.6f, 0.0f),      // 橙色
-    RED("red", "高贵红", 1.0f, 0.2f, 0.2f);            // 红色
+    DEFAULT("default", "默认", 1.0f, 1.0f, 1.0f),
+    GREEN("green", "绿色", 0.2f, 0.8f, 0.2f),
+    CYAN("cyan", "青色", 0.0f, 0.8f, 0.8f),
+    BLUE("blue", "高贵蓝", 0.3f, 0.5f, 1.0f),
+    PURPLE("purple", "高贵紫", 0.7f, 0.3f, 1.0f),
+    PINK("pink", "粉色", 1.0f, 0.4f, 0.7f),
+    ORANGE("orange", "高贵橙", 1.0f, 0.6f, 0.0f),
+    RED("red", "高贵红", 1.0f, 0.2f, 0.2f);
 
     private final String id;
     private final String displayName;
-    private final float r, g, b;  // RGB颜色值（0.0-1.0）
+    private final float r;
+    private final float g;
+    private final float b;
 
     BorderTheme(String id, String displayName, float r, float g, float b) {
         this.id = id;

--- a/targets/forge-1.20.1/src/main/java/com/sighs/petiteinventory/inventory/ItemInventoryService.java
+++ b/targets/forge-1.20.1/src/main/java/com/sighs/petiteinventory/inventory/ItemInventoryService.java
@@ -1,18 +1,13 @@
 package com.sighs.petiteinventory.inventory;
 
-import com.sighs.petiteinventory.compat.KubeJSCompat;
-import com.sighs.petiteinventory.inventory.Area;
-import com.sighs.petiteinventory.inventory.AreaEvent;
 import com.sighs.petiteinventory.config.ItemSizeRuleCache;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.tags.ItemTags;
 import net.minecraft.tags.TagKey;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
-import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.registries.ForgeRegistries;
 import net.minecraftforge.registries.tags.ITagManager;
-import org.jetbrains.annotations.NotNull;
 
 import java.util.*;
 import java.util.stream.Collectors;
@@ -20,50 +15,27 @@ import java.util.stream.Collectors;
 public class ItemInventoryService {
     private static final TagKey<Item> TOOLS_TAG =
             ItemTags.create(new ResourceLocation("forge", "tools"));
-    private static final TagKey<net.minecraft.world.item.Item> SWORDS_TAG =
+    private static final TagKey<Item> SWORDS_TAG =
             ItemTags.create(new ResourceLocation("forge", "swords"));
 
     private static final String TAG = "PetiteRotated";
 
-    /**
-     * 检查ItemStack是否为工具或武器
-     * @param stack 待检查的物品堆栈
-     * @return 如果是工具或武器返回true，否则返回false
-     */
     public static boolean isToolOrWeapon(ItemStack stack) {
         if (stack.isEmpty()) return false;
 
-        if (stack.is(ItemTags.TOOLS)) {
-            return true;
-        }
-
-        if (stack.is(ItemTags.SWORDS)) {
-            return true;
-        }
-
-        if (stack.is(TOOLS_TAG)) {
-            return true;
-        }
-
-        if (stack.is(SWORDS_TAG)) {
-            return true;
-        }
-
-        return false;
+        if (stack.is(ItemTags.TOOLS)) return true;
+        if (stack.is(ItemTags.SWORDS)) return true;
+        if (stack.is(TOOLS_TAG)) return true;
+        return stack.is(SWORDS_TAG);
     }
 
-    /**
-     * 比较两个ItemStack是否相同（忽略旋转标记）
-     */
     public static boolean isSameItemIgnoreRotate(ItemStack stack1, ItemStack stack2) {
         if (stack1 == stack2) return true;
         if (stack1.isEmpty() || stack2.isEmpty()) return false;
         if (stack1.getItem() != stack2.getItem()) return false;
 
-        // 复制物品栈并移除旋转标记后比较
         ItemStack copy1 = stack1.copy();
         ItemStack copy2 = stack2.copy();
-
         ItemRotateHelper.setRotated(copy1, false);
         ItemRotateHelper.setRotated(copy2, false);
 
@@ -73,52 +45,34 @@ public class ItemInventoryService {
     public static class ItemRotateHelper {
         public static final String TAG = "PetiteRotated";
 
-        /** 写：客户端用 */
         public static void setRotated(ItemStack stack, boolean rotated) {
             if (rotated) {
                 stack.getOrCreateTag().putBoolean(TAG, true);
-            } else {
-                if (stack.hasTag()) {
-                    stack.getTag().remove(TAG);
-                    if (stack.getTag().isEmpty()) stack.setTag(null);
-                }
+            } else if (stack.hasTag()) {
+                stack.getTag().remove(TAG);
+                if (stack.getTag().isEmpty()) stack.setTag(null);
             }
         }
 
-        /** 读：两端都用 */
         public static boolean isRotated(ItemStack stack) {
             return stack.hasTag() && stack.getTag().getBoolean(TAG);
         }
     }
 
     public static String getItemRegistryName(Item item) {
-        if (item == null) {
-            return null;
-        }
+        if (item == null) return null;
 
         ResourceLocation registryName = ForgeRegistries.ITEMS.getKey(item);
-        if (registryName == null) {
-            return null;
-        }
-
-        return registryName.toString();
+        return registryName == null ? null : registryName.toString();
     }
 
     public static Item getItemById(String registryName) {
-        if (registryName == null || registryName.isEmpty()) {
-            return null;
-        }
+        if (registryName == null || registryName.isEmpty()) return null;
 
         try {
             ResourceLocation resourceLocation = new ResourceLocation(registryName);
-
-            if (!ForgeRegistries.ITEMS.containsKey(resourceLocation)) {
-                return null;
-            }
-
-            Item item = ForgeRegistries.ITEMS.getValue(resourceLocation);
-
-            return item;
+            if (!ForgeRegistries.ITEMS.containsKey(resourceLocation)) return null;
+            return ForgeRegistries.ITEMS.getValue(resourceLocation);
         } catch (Exception e) {
             return null;
         }
@@ -152,34 +106,25 @@ public class ItemInventoryService {
                 try {
                     ResourceLocation tagId = new ResourceLocation(tagIdString);
                     Collection<Item> tagItems = getItemsOfTag(tagId);
-                    if (tagItems.isEmpty()) {
-                    } else {
-                        result.addAll(tagItems);
-                    }
-                } catch (Exception ignored) {}
+                    if (!tagItems.isEmpty()) result.addAll(tagItems);
+                } catch (Exception ignored) {
+                }
             } else {
                 Item item = getItemById(id);
-                if (item != null) {
-                    result.add(item);
-                }
+                if (item != null) result.add(item);
             }
         }
-
         return result;
     }
 
     public static List<ResourceLocation> getItemTags(Item item) {
         ITagManager<Item> tagManager = ForgeRegistries.ITEMS.tags();
-
-        if (tagManager == null) {
-            return Collections.emptyList();
-        }
+        if (tagManager == null) return Collections.emptyList();
 
         return tagManager.getReverseTag(item)
-                .map(reverseTag ->
-                        reverseTag.getTagKeys()
-                                .map(TagKey::location)
-                                .collect(Collectors.toList()))
+                .map(reverseTag -> reverseTag.getTagKeys()
+                        .map(TagKey::location)
+                        .collect(Collectors.toList()))
                 .orElse(Collections.emptyList());
     }
 
@@ -188,40 +133,20 @@ public class ItemInventoryService {
     }
 
     public static Area getArea(ItemStack itemStack) {
-        // 1. 首先检查NBT精确匹配（最高优先级）
-        String itemId = getItemRegistryName(itemStack.getItem());
-        if (itemId != null && !itemStack.isEmpty()) {
-            // 生成NBT键格式，检查是否为NBT物品
-            String nbtKey = getNBTKey(itemId, itemStack);
-            if (nbtKey != null) {
-                String nbtSize = ItemSizeRuleCache.NBTMapCache.get(nbtKey);
-                if (nbtSize != null) {
-                    // 解析尺寸并应用旋转
-                    String[] size = nbtSize.replace(" ", "").split("\\*");
-                    int width = Integer.parseInt(size[0]);
-                    int height = Integer.parseInt(size[1]);
-
-                    boolean rotated = ItemRotateHelper.isRotated(itemStack);
-                    if (rotated) {
-                        int tmp = width;
-                        width = height;
-                        height = tmp;
-                    }
-
-                    return new Area(width, height, itemStack);
-                }
-            }
+        if (itemStack == null || itemStack.isEmpty()) {
+            return new Area(1, 1, itemStack);
         }
 
-        // 2. 尝试普通ID匹配
-        String normalSize = ItemSizeRuleCache.matchItem(itemId);
-        if (normalSize != null) {
-            String[] size = normalSize.replace(" ", "").split("\\*");
+        String itemId = getItemRegistryName(itemStack.getItem());
+
+        // NBT exact match > normal ID > tag match.
+        String configuredSize = itemId == null ? null : ItemSizeRuleCache.matchItem(itemId, itemStack);
+        if (configuredSize != null) {
+            String[] size = configuredSize.replace(" ", "").split("\\*");
             int width = Integer.parseInt(size[0]);
             int height = Integer.parseInt(size[1]);
 
-            boolean rotated = ItemRotateHelper.isRotated(itemStack);
-            if (rotated) {
+            if (ItemRotateHelper.isRotated(itemStack)) {
                 int tmp = width;
                 width = height;
                 height = tmp;
@@ -230,26 +155,6 @@ public class ItemInventoryService {
             return new Area(width, height, itemStack);
         }
 
-        // 3. 默认1×1
         return new Area(1, 1, itemStack);
-    }
-
-    /**
-     * 从ItemStack生成NBT精确匹配键
-     */
-    private static String getNBTKey(String itemId, ItemStack stack) {
-        if (!stack.hasTag()) return null;
-
-        // TACZ枪械支持
-        if (itemId.equals("tacz:modern_kinetic_gun") && stack.getTag().contains("GunId")) {
-            String gunId = stack.getTag().getString("GunId");
-            if (gunId != null && !gunId.isEmpty()) {
-                return itemId + "{GunId:\"" + gunId + "\"}";
-            }
-        }
-
-        // 可以扩展其他模组的NBT匹配规则
-
-        return null;
     }
 }


### PR DESCRIPTION
This contribution extends TaCZ NBT support for configurable item sizes and background colors.

Added support for:
- Weapons through GunId
- Magazines through MagazineFamily
- Sights and attachments through AttachmentId
- Additional background color themes

The changes were tested in my modified PetiteInventory build. Please review and test compatibility with the current master branch.

Contribution by Tnazv333 / VIVI2.